### PR TITLE
[Dependency Radar] {master} Update "gulp-tar" from "^1.9.0" to "2.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-istanbul": "^1.1.1",
     "gulp-mocha": "^3.0.1",
     "gulp-nodemon": "^2.2.1",
-    "gulp-tar": "^1.9.0",
+    "gulp-tar": "2.1.0",
     "mocha-lcov-reporter": "^1.2.0",
     "run-sequence": "^1.2.2",
     "supertest": "^2.0.1"


### PR DESCRIPTION

This pull request is created in order to update "gulp-tar" from "^1.9.0" to "2.1.0".
